### PR TITLE
Disable reserved blocks for privileged processes for ext3/ext4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Disable reserved blocks for privileged processes for `ext3` and `ext4` volumes
+
 * Update to CSI spec v1.0.0
 
 * Forked this repository from csi-digitalocean. They have a similar API. Thanks

--- a/driver/mounter.go
+++ b/driver/mounter.go
@@ -97,7 +97,11 @@ func (m *mounter) Format(source, fsType string) error {
 
 	mkfsArgs = append(mkfsArgs, source)
 	if fsType == "ext4" || fsType == "ext3" {
-		mkfsArgs = []string{"-F", source}
+		mkfsArgs = []string{
+			"-F",  // Force flag
+			"-m0", // Zero blocks reserved for privileged processes
+			source,
+		}
 	}
 
 	m.log.WithFields(logrus.Fields{


### PR DESCRIPTION
When creating ext3/ext4 volume, pass -m0 to mkfs in order to disable
reserved blocks for privileged processes, which otherwise defaults to 5%
of the entire disk.

Rationale: Reserving a percentage of the volume is generally a neither
useful nor desirable feature for volumes that aren't used as root file
systems for Linux distributions, since the reserved portion becomes
unavailable for non-root users. For containers, the general case is to
use the entire volume for data, without running as root. The case where
one might want reserved blocks enabled is much rarer.

See kubernetes/kubernetes@1b3dee9