### PR TITLE
Read the cloudscale.ch access token from an environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Read cloudscale.ch access token from environment variable
+
 * Disable reserved blocks for privileged processes for `ext3` and `ext4` volumes
 
 * Update to CSI spec v1.0.0

--- a/cmd/cloudscale-csi-plugin/main.go
+++ b/cmd/cloudscale-csi-plugin/main.go
@@ -35,6 +35,10 @@ func main() {
 	)
 	flag.Parse()
 
+	if *token == "" {
+		*token = os.Getenv("CLOUDSCALE_ACCESS_TOKEN")
+	}
+
 	if *version {
 		fmt.Printf("%s - %s (%s)\n", driver.GetVersion(), driver.GetCommit(), driver.GetTreeState())
 		os.Exit(0)

--- a/deploy/kubernetes/releases/csi-cloudscale-dev.yaml
+++ b/deploy/kubernetes/releases/csi-cloudscale-dev.yaml
@@ -148,7 +148,6 @@ spec:
           image: cloudscalech/cloudscale-csi-plugin:dev
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--token=$(CLOUDSCALE_ACCESS_TOKEN)"
             - "--url=$(CLOUDSCALE_API_URL)"
           env:
             - name: CSI_ENDPOINT
@@ -342,7 +341,6 @@ spec:
           imagePullPolicy: "Always"
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--token=$(CLOUDSCALE_ACCESS_TOKEN)"
             - "--url=$(CLOUDSCALE_API_URL)"
           env:
             - name: CSI_ENDPOINT


### PR DESCRIPTION
If we pass it as a command-line argument, the token is exposed to
everything than can read the host system's `/proc` filesystem.