### PR TITLE
Add support for Kubernetes 1.22.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Ensure go.mod and modules.txt are up to date. Revendor github.com/googleapis.
 * Support raw block volume mode (not in conjunction with LUKS for now)
 * Update go libraries.
+* Add support for Kubernetes 1.22
 
 ## v3.0.0 - 2021.08.31
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ The following table describes the required cloudsdcale.ch driver version per Kub
 
 Kubernetes Release | cloudscale.ch CSI Driver Version
 ------------------ | -------------------------------
-1.13 - 1.16        | latest v1.x release 
-1.17 or later      | latest v2.x or newer release
+1.13 - 1.16        | latest v1.x.x release 
+1.17 - 1.21        | latest v2.x.x or newer release
+1.22 or later      | latest v3.1.x or newer release
 
 **Requirements:**
 

--- a/deploy/kubernetes/releases/csi-cloudscale-dev.yaml
+++ b/deploy/kubernetes/releases/csi-cloudscale-dev.yaml
@@ -17,7 +17,7 @@
 # Install the CSI Driver. This simplifies driver discovery and enables us to
 # customize Kubernetes behavior
 # https://kubernetes-csi.github.io/docs/csi-driver-object.html
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: csi.cloudscale.ch


### PR DESCRIPTION
`storage.k8s.io/v1beta1` is no longer available in Kubernetes 1.22.
This release ensures compatibility.