### PR TITLE
Add missing steps to deploy/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![test](https://github.com/cloudscale-ch/csi-cloudscale/actions/workflows/test.yaml/badge.svg)](https://github.com/cloudscale-ch/csi-cloudscale/actions/workflows/test.yaml)
 
-A Container Storage Interface ([CSI](https://github.com/container-storage-interface/spec)) Driver for cloudscale.ch volumes. The CSI plugin allows you to use cloudscale.ch volumes with your preferred Container Orchestrator.
+A Container Storage Interface ([CSI](https://github.com/container-storage-interface/spec)) driver for cloudscale.ch volumes. The CSI plugin allows you to use cloudscale.ch volumes with your preferred Container Orchestrator.
 
-The cloudscale.ch CSI plugin is mostly tested on Kubernetes. Theoretically it
-should also work on other Container Orchestrators, such as Mesos or
-Cloud Foundry. Feel free to test it on other COs and give us a feedback.
+The cloudscale.ch CSI plugin is mostly tested on Kubernetes. In theory, it
+should also work on other Container Orchestrators like Mesos or
+Cloud Foundry. Feel free to test it on other COs and give us feedback.
 
 ## TL;DR
 
@@ -21,7 +21,7 @@ $ helm install -n kube-system -g csi-cloudscale/csi-cloudscale
 
 ## Volume parameters
 
-This plugin supports the following volume parameters (in case of kubernetes: parameters on the 
+This plugin supports the following volume parameters (in case of Kubernetes: parameters on the 
 `StorageClass` object):
 
 * `csi.cloudscale.ch/volume-type`: `ssd` or `bulk`; defaults to `ssd` if not set
@@ -30,7 +30,7 @@ For LUKS encryption:
 
 * `csi.cloudscale.ch/luks-encrypted`: set to the string `"true"` if the volume should be encrypted
   with LUKS
-* `csi.cloudscale.ch/luks-cipher`: cipher to use; must be supported by the kernel and luks, we
+* `csi.cloudscale.ch/luks-cipher`: cipher to use; must be supported by the kernel and LUKS, we
   suggest `aes-xts-plain64`
 * `csi.cloudscale.ch/luks-key-size`: key-size to use; we suggest `512` for `aes-xts-plain64`
 
@@ -44,16 +44,16 @@ folder for examples.
 The default deployment bundled in the `deploy/kubernetes/releases` folder includes the following
 storage classes:
 
-* `cloudscale-volume-ssd` - the default storage class; uses an ssd volume, no luks encryption
-* `cloudscale-volume-bulk` - uses a bulk volume, no luks encryption
-* `cloudscale-volume-ssd-luks` - uses an ssd volume that will be encrypted with luks; a luks-key
+* `cloudscale-volume-ssd` - the default storage class; uses an ssd volume, no LUKS encryption
+* `cloudscale-volume-bulk` - uses a bulk volume, no LUKS encryption
+* `cloudscale-volume-ssd-luks` - uses an ssd volume that will be encrypted with LUKS; a luks-key
   must be supplied
-* `cloudscale-volume-bulk-luks` - uses a bulk volume that will be encrypted with luks; a luks-key
+* `cloudscale-volume-bulk-luks` - uses a bulk volume that will be encrypted with LUKS; a luks-key
   must be supplied
 
-To use one of the shipped luks storage classes, you need to create a secret named 
+To use one of the shipped LUKS storage classes, you need to create a secret named 
 `${pvc.name}-luks-key` in the same namespace as the persistent volume claim. The secret must
-contain an element called `luksKey` that will be used as the luks encryption key.
+contain an element called `luksKey` that will be used as the LUKS encryption key.
 
 Example: If you create a persistent volume claim with the name `my-pvc`, you need to create a
 secret `my-pvc-luks-key`.
@@ -74,7 +74,7 @@ The current version is: **`v3.5.2`**.
 The following table describes the required cloudscale.ch driver version per Kubernetes release.
 We recommend using the latest cloudscale.ch CSI driver compatible with your Kubernetes release.
 
-| Kubernetes Release | Minimum cloudscale.ch CSI Driver | Maximum cloudscale.ch CSI Driver |
+| Kubernetes Release | Minimum cloudscale.ch CSI driver | Maximum cloudscale.ch CSI driver |
 |--------------------|----------------------------------|----------------------------------|
 | <= 1.16            |                                  | v1.3.1                           |
 | 1.17               | v1.3.1                           | v3.0.0                           |
@@ -86,6 +86,7 @@ We recommend using the latest cloudscale.ch CSI driver compatible with your Kube
 | 1.23               | v3.1.0                           | v3.5.2                           |
 | 1.24               | v3.1.0                           | v3.5.2                           |
 | 1.25               | v3.3.0                           | v3.5.2                           |
+| 1.26               | v3.3.0                           | v3.5.2                           |
 
 **Requirements:**
 
@@ -156,8 +157,8 @@ For a complete list please refer to [values.yaml](./charts/csi-cloudscale/values
 | Parameter                           | Default                      | Description                                                                                |
 |-------------------------------------|------------------------------|--------------------------------------------------------------------------------------------|
 | attacher.resources                  | `{}`                         | Resource limits and requests for the attacher side-car.                                    |
-| cloudscale.apiUrl                   | `https://api.cloudscale.ch/` | URL of the cloudscale.ch API. You can almost certainly use the default                     |
-| cloudscale.max_csi_volumes_per_node | `125`                        | Override [max. Number of CSI Volumes per Node](#Max.-Number-of-CSI-Volumes-per-Node)       |
+| cloudscale.apiUrl                   | `https://api.cloudscale.ch/` | URL of the cloudscale.ch API. You can almost certainly use the default.                    |
+| cloudscale.max_csi_volumes_per_node | `125`                        | Override [max. Number of CSI Volumes per Node](#Max.-Number-of-CSI-Volumes-per-Node).      |
 | cloudscale.token.existingSecret     | `cloudscale`                 | Name of the Kubernetes Secret which contains the cloudscale.ch API Token.                  |
 | controller.resources                | `{}`                         | Resource limits and requests for the controller container.                                 |
 | controller.serviceAccountName       | `null`                       | Override the controller service account name.                                              |
@@ -222,10 +223,10 @@ The above output means that the CSI plugin successfully created (provisioned) a
 new Volume on behalf of you. You should be able to see this newly created
 volumes in the server detail view in the cloudscale.ch UI.
 
-The volume is not attached to any node yet. It'll only attached to a node if a
+The volume is not attached to any node yet. It will only attach to a node if a
 workload (i.e: pod) is scheduled to a specific node. Now let us create a Pod
 that refers to the above volume. When the Pod is created, the volume will be
-attached, formatted and mounted to the specified Container:
+attached, formatted and mounted to the specified container:
 
 ```
 kind: Pod

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,9 +2,12 @@
 
 ## Testing
 
-To test kubernetes csi-cloudscale on kubernetes, you can install
-kubespray to deploy kubernetes:
+To test csi-cloudscale on Kubernetes, you can install kubespray to deploy Kubernetes:
 
+    cd deploy
+    # kubspray is provided as a git submodule
+    git submodule init
+    git submodule update
     python3 -m venv venv
     . venv/bin/activate
     # or requirements-{VERSION}.txt, see https://github.com/kubernetes-sigs/kubespray/blob/master/docs/ansible.md#ansible-python-compatibility
@@ -15,15 +18,13 @@ After this you run:
 
     CLOUDSCALE_TOKEN="foobar" ansible-playbook ../integration_test.yml -i inventory/hosts.ini
 
-to install kubernetes on cloudscale.ch and run the integration tests.
+to install Kubernetes on cloudscale.ch and run the integration tests.
 The playbook will also clean up VMs after the test.
 
 -   If you just want to provision a cluster, you can use an additional
     `--skip-tags cleanup --skip-tags test`.
 -   If you want to a test release other than `dev`, you can use an
-    additional `-e version=v1.0.0`.
--   If you want to use a non-default Kubernetes version, you can use an
-    additional `-e kube_version=v1.20.7`.
+    additional `-e version=v1.0.0`. Caution: This does only inject the docker image tag in to helm, but uses the chart from the current working directory.
 
 ## Debugging
 
@@ -36,7 +37,7 @@ You can just redeploy all csi pods and push a new version to docker hub:
 Kubernetes will then automatically reinstall the pods you just deleted
 with newer versions.
 
-To follow logs on kubernetes master server:
+To follow logs on Kubernetes master server:
 
     kubectl logs -n kube-system csi-cloudscale-controller-0 --all-containers --timestamps -f
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,27 +2,52 @@
 
 ## Testing
 
-To test csi-cloudscale on Kubernetes, you can install kubespray to deploy Kubernetes:
+To test csi-cloudscale in conjunction with Kubernetes, a suite of integration tests has been implemented.
+To run this test suite, a Kubernetes cluster is required. For this purpose, this setup was prepared using kubespray.
 
-    cd deploy
+> ⚠️ Running these tests yourself may incur unexpected costs and may result in data loss if run against a production account with live systems. herefore, we strongly advise you to use a separate account for these tests. 
+> The Kubernetes cluster created is not production ready and should not be used for any purpose other than testing.
+
+
+    # setup all required charts in the local folder, as they will be used by the ansible playbook.
+    cd charts/csi-cloudscale/
+    helm repo add bitnami https://charts.bitnami.com/bitnami
+    helm repo update
+    helm dependency build
+    cd ../../
+    
     # kubspray is provided as a git submodule
     git submodule init
     git submodule update
+    # if you want to test against another Kubernetes version, checkout a differnt tag in the the kubspray folder
+    
+    # setup the python venv
+    cd deploy
     python3 -m venv venv
     . venv/bin/activate
     # or requirements-{VERSION}.txt, see https://github.com/kubernetes-sigs/kubespray/blob/master/docs/ansible.md#ansible-python-compatibility
     pip install -r kubespray/requirements.txt
+    
+    # setup the cluster    
     cd kubespray/
+    # get a token from the cloudscale.ch Control Panel and set it as CLOUDSCALE_TOKEN envrionment variable
+    export CLOUDSCALE_TOKEN="foobar"
+    # running this playbook will install a Kubernetes cluster on cloudscale.ch
+    ansible-playbook ../integration_test.yml -i inventory/hosts.ini --skip-tags cleanup --skip-tags test
 
-After this you run:
+    # get the IP address of server "test-kubernetes-master" from the cloudscale.ch Control Panel
+    # add the IP in the property "server" in the file "kubeconfig.yml", keep the https prefix and the port
+    cd ../../
+    vi deploy/kubeconfig.yml
 
-    CLOUDSCALE_TOKEN="foobar" ansible-playbook ../integration_test.yml -i inventory/hosts.ini
+    # add the path of this file to the KUBECONFIG env variable
+    export KUBECONFIG=$(pwd)/deploy/kubeconfig.yml
 
-to install Kubernetes on cloudscale.ch and run the integration tests.
-The playbook will also clean up VMs after the test.
+    # finally, run the integration tests
+    make test-integration
 
--   If you just want to provision a cluster, you can use an additional
-    `--skip-tags cleanup --skip-tags test`.
+*Command line options for the playbook:*  
+-   If you just want to provision a cluster, you can use an additional `--skip-tags cleanup --skip-tags test`.
 -   If you want to a test release other than `dev`, you can use an
     additional `-e version=v1.0.0`. Caution: This does only inject the docker image tag in to helm, but uses the chart from the current working directory.
 


### PR DESCRIPTION
To test csi-cloudscale in conjunction with Kubernetes, a suite of integration tests has been implemented.
To run this test suite, a Kubernetes cluster is required. A setup using kubespray was documented for this purpose. 
Some important steps were missing.